### PR TITLE
docker-compose.yml Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # celery-docker
+
+## using `docker-compose`
+
+### Up
+`$ docker-compose up -d`
+
+### Scale
+`$ docker-compose up -d --scale worker=2`
+`$ docker-compose up -d --scale worker=1`
+
+### Down
+`$ docker-compose down`
+
+## using `docker-stack`
+
+### Up
+`$ docker stack deploy -c docker-stack.yml celery-docker-example`
+
+### Scale
+`$ docker service scale celery-docker-example_worker=2`
+`$ docker service scale celery-docker-example_worker=1`
+
+### Down
+`$ docker stack rm celery-docker-example`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
 
   minio:
     image: minio/minio:RELEASE.2018-11-06T01-01-02Z
-    command: server /export
+    command: server /data
     environment: *env
     ports:
       - 80:9000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     depends_on:
       - beat
       - rabbitmq
+      - minio
     restart: 'no'
 
   beat:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,6 @@ services:
       - beat
       - rabbitmq
     restart: 'no'
-    volumes: 
-      - ./app:/app
 
   worker-minio:
     build: .
@@ -27,8 +25,6 @@ services:
       - beat
       - rabbitmq
     restart: 'no'
-    volumes: 
-      - ./app:/app
 
   beat:
     build: .
@@ -38,8 +34,6 @@ services:
     depends_on: 
       - rabbitmq
     restart: 'no'
-    volumes: 
-      - ./app:/app
 
   rabbitmq:
     image: rabbitmq:3.7.8

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -1,0 +1,58 @@
+version: '3.4'
+services:
+  worker:
+    image: &img worker
+    command: [celery, worker, --app=worker.app, --pool=gevent, --concurrency=20, --loglevel=INFO]
+    environment: &env
+      - CELERY_BROKER_URL=amqp://guest:guest@rabbitmq:5672
+      - MINIO_HOST=minio:9000
+      - MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE
+      - MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+      - NEWSPAPER_URLS=https://www.theguardian.com,https://www.nytimes.com
+      - NEWSPAPER_SCHEDULE=300
+    depends_on:
+      - beat
+      - rabbitmq
+    deploy:
+      restart_policy:
+        condition: 'none'
+
+  worker-minio:
+    image: *img
+    command: [celery, worker, --app=worker.app, --pool=gevent, --concurrency=20, --queues=minio, --loglevel=INFO]
+    environment: *env
+    depends_on:
+      - beat
+      - rabbitmq
+      - minio
+    deploy:
+      restart_policy:
+        condition: 'none'
+
+  beat:
+    image: *img
+    command: [celery, beat, --app=worker.app, --loglevel=INFO]
+    environment: *env
+    depends_on: 
+      - rabbitmq
+    deploy:
+      restart_policy:
+        condition: 'none'
+
+  rabbitmq:
+    image: rabbitmq:3.7.8
+
+  minio:
+    image: minio/minio:RELEASE.2018-11-06T01-01-02Z
+    command: server /data
+    environment: *env
+    ports:
+      - 80:9000
+    volumes:
+      - minio:/data
+    deploy:
+      placement:
+        constraints: [node.role == manager]
+
+volumes:
+  minio:


### PR DESCRIPTION
I followed the tutorial originally posted and soon after decided to do some testing on the result. I found that the data stored by minio was not persistent across restarts of the service. I ended up finding a bug in the compose file regarding the minio storage path.

I started to also question how the docker-compose.yml file could be simplified. I found that I could remove the `app` directory mounts because the necessary files had already been copied into the docker images.

I began experimenting with `docker stack` which takes some slightly different syntax regarding the restart policy as well as not allowing the `build` key. I decided to create a `docker-stack.yml` file for myself and wanted to give back to the tutorial if it indeed adds benefit.